### PR TITLE
added id field to coin schema

### DIFF
--- a/src/modules/models/Coin.js
+++ b/src/modules/models/Coin.js
@@ -2,10 +2,14 @@ const mongoose = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
 
 const coinShema = mongoose.Schema({
+    id: {
+        type: String,
+        required: [true, 'ID is required'],
+        unique: true,
+    },
     name: {
         type: String,
         required: [true, 'Name is required'],
-        unique: true,
     },
     price: {
         type: Number,
@@ -21,12 +25,11 @@ const coinShema = mongoose.Schema({
     },
     volume: {
         type: Number,
-        required: [true, 'volume is required']
+        required: [true, 'Volume is required']
     },
     marketCap: {
         type: Number,
         required: [true, 'Market cap value is required'],
-        unique: true,
     },
     liquidity: {
         type: Number,

--- a/src/modules/models/Coin.js
+++ b/src/modules/models/Coin.js
@@ -29,7 +29,27 @@ const coinShema = mongoose.Schema({
     },
     marketCap: {
         type: Number,
-        required: [true, 'Market cap value is required'],
+        required: [true, 'Market Cap value is required'],
+    },
+    marketCapRank: {
+        type: Number,
+        required: [true, 'Market Cap rank is required'],
+    },
+    maxSupply: {
+        type: Number,
+        required: [true, 'Max Supply is required'],
+    },
+    allTimeHigh: {
+        type: Number,
+        required: [true, 'All Time High is required'],
+    },
+    allTimeLow: {
+        type: Number,
+        required: [true, 'All Time Low is required'],
+    },
+    circulatingSupply: {
+        type: Number,
+        required: [true, 'Circulating Supply is required'],
     },
     liquidity: {
         type: Number,


### PR DESCRIPTION
since name filed should be used as a showing field, we also need an id field for us to identify the coin. The id can be a number but we also use string. example: btc for Bitcoin or 2 for Etherium.